### PR TITLE
Remove tech preview section

### DIFF
--- a/asciidoc/modules/con_mg_changes-in-vertx-web-graphql.adoc
+++ b/asciidoc/modules/con_mg_changes-in-vertx-web-graphql.adoc
@@ -5,13 +5,6 @@ The following section describes the changes in {VertX} Web GraphQL.
 
 == Updated methods to be supported on multi-language (polyglot) environments
 
-{VertX} Web GraphQL is available as Technology Preview.
-
-[NOTE]
-====
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-
 The following methods have been updated and are now supported on polyglot environments:
 * `UploadScalar` is now a factory, use the method  `UploadScalar.create()` instead.
 


### PR DESCRIPTION
This is the only section mentioning Technology Preview and is referencing content for a Red Hat product.  References like that should not be included in community documentation.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
