### PR TITLE
document OAuth2ClientOptions to OAuth2Options change

### DIFF
--- a/asciidoc/modules/con_mg_deprecated-and-removed-authentication-and-authorization-methods.adoc
+++ b/asciidoc/modules/con_mg_deprecated-and-removed-authentication-and-authorization-methods.adoc
@@ -5,14 +5,22 @@ The following sections list methods deprecated and removed for authentication an
 
 == List of removed authentication and authorization methods
 
+The following classes have been renamed:
+
+[options="header"]
+|===
+|3.x|4.x
+|`OAuth2ClientOptions`| `OAuth2Options`
+|===
+
 The following methods have been removed:
 
 [options="header"]
 |===
 |Removed methods|Replacing methods
 |`OAuth2Auth.createKeycloak()`| `KeycloakAuth.create(vertx, JsonObject) ()`
-|`OAuth2Auth.create(Vertx, OAuth2FlowType, OAuth2ClientOptions)()`| `OAuth2Auth.create(vertx, new OAuth2ClientOptions().setFlow(YOUR_DESIRED_FLOW))`
-|`OAuth2Auth.create(Vertx, OAuth2FlowType)`| `OAuth2Auth.create(vertx, new OAuth2ClientOptions().setFlow(YOUR_DESIRED_FLOW))`
+|`OAuth2Auth.create(Vertx, OAuth2FlowType, OAuth2ClientOptions)()`| `OAuth2Auth.create(vertx, new OAuth2Options().setHttpClientOptions(new HttpClientOptions()).setFlow(YOUR_DESIRED_FLOW))`
+|`OAuth2Auth.create(Vertx, OAuth2FlowType)`| `OAuth2Auth.create(vertx, new OAuth2Options().setHttpClientOptions(new HttpClientOptions()).setFlow(YOUR_DESIRED_FLOW))`
 |`User.isAuthorised()`|`User.isAuthorized()`
 |`User.setAuthProvider()`|No replacing method
 |`AccessToken.refreshToken()`|`AccessToken.opaqueRefreshToken()`
@@ -31,7 +39,7 @@ The following methods have been deprecated:
 |`OAuth2Auth.decodeToken()`|`AuthProvider.authenticate()`
 |`OAuth2Auth.introspectToken()`|`AuthProvider.authenticate()`
 |`OAuth2Auth.getFlowType()`| No replacing method
-|`OAuth2Auth.loadJWK()`|`OAuth2Auth.jwkSet()`
+|`OAuth2Auth.loadJWK()`|`OAuth2Auth.jWKSet()`
 |`Oauth2ClientOptions.isUseAuthorizationHeader()`|No replacing method
 |===
 


### PR DESCRIPTION
Motivation:

[OAuth documentation](https://vert-x3.github.io/vertx-4-migration-guide/index.html#deprecated-and-removed-authentication-and-authorization-methods_authentication-and-authorization) is missing this [commit](https://github.com/vert-x3/vertx-auth/commit/c00b6f860d23c00f802edea6d15820667ab63470)

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
