### PR TITLE
[HttpClient-changes] handler the request-response in vertx4

### DIFF
--- a/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
+++ b/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
@@ -201,3 +201,36 @@ response.end(ar -> {
   }
 });
 ----
++
+
+On the other hand, we can handle the response with some operations if we want to. You can see the difference in the next examples.
+
+The following example shows an example using HTTP client in {VertX} {v3x} releases:
+
+----
+HttpClient client = vertx.createHttpClient(options);
+
+    client.request(HttpMethod.GET, 8443, "localhost", "/")
+      .onSuccess(request -> {
+        request.onSuccess(resp -> {
+
+        //Handler some operation with the response
+        });
+      });
+----
+
+The following example shows an example using HTTP client with the result method in {VertX} {v4x} releases:
+
+----
+HttpClient client = vertx.createHttpClient(options);
+
+    client.request(HttpMethod.GET, 8443, "localhost", "/")
+      .onSuccess(request -> {
+        request.response().onSuccess(resp -> {
+
+        //Handler some operation with the response
+        });
+      });
+----
+
+

--- a/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
+++ b/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
@@ -203,10 +203,11 @@ response.end(ar -> {
 ----
 +
 
-On the other hand, you can also handle the response with operations like onSuccess, compose, bodyHandler, etc.
+On the other hand, you can also handle the response with method such as onSucces(), compose(), bodyHandler() and so on.
+
 The following examples demonstrate handling responses with the operation onSuccess :
 
-The following example shows an example using HTTP client in {VertX} {v3x} releases:
+The following example shows how to use HTTP client with the result() method in {VertX} {v3x} releases:
 
 ----
 HttpClient client = vertx.createHttpClient(options);
@@ -220,7 +221,7 @@ HttpClient client = vertx.createHttpClient(options);
       });
 ----
 
-The following example shows an example using HTTP client with the result method in {VertX} {v4x} releases:
+The following example shows how to use HTTP client with the result() method in {VertX} {v4x} releases:
 
 ----
 HttpClient client = vertx.createHttpClient(options);

--- a/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
+++ b/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
@@ -201,14 +201,12 @@ response.end(ar -> {
   }
 });
 ----
-+
 
-On the other hand, you can also handle the response with method such as onSucces(), compose(), bodyHandler() and so on.
+You can also handle the response with methods such as, `onSucces()`, `compose()`, `bodyHandler()` and so on. The following examples demonstrate handling responses using the `onSuccess()` method.
 
-The following examples demonstrate handling responses with the operation onSuccess :
+The following example shows how to use HTTP client with the `result()` method in {VertX} {v3x} releases.
 
-The following example shows how to use HTTP client with the result() method in {VertX} {v3x} releases:
-
+[source,java,options="nowrap",subs="attributes+"]
 ----
 HttpClient client = vertx.createHttpClient(options);
 
@@ -216,13 +214,14 @@ HttpClient client = vertx.createHttpClient(options);
       .onSuccess(request -> {
         request.onSuccess(resp -> {
 
-        //Handler some operation with the response
+        //Code to handle HTTP response
         });
       });
 ----
 
-The following example shows how to use HTTP client with the result() method in {VertX} {v4x} releases:
+The following example shows how to use HTTP client with the `result()` method in {VertX} {v4}.
 
+[source,java,options="nowrap",subs="attributes+"]
 ----
 HttpClient client = vertx.createHttpClient(options);
 
@@ -230,9 +229,7 @@ HttpClient client = vertx.createHttpClient(options);
       .onSuccess(request -> {
         request.response().onSuccess(resp -> {
 
-        //Handler some operation with the response
+        //Code to handle HTTP response
         });
       });
 ----
-
-

--- a/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
+++ b/asciidoc/modules/con_mg_migrating-applications-to-vertx-http-client.adoc
@@ -203,7 +203,8 @@ response.end(ar -> {
 ----
 +
 
-On the other hand, we can handle the response with some operations if we want to. You can see the difference in the next examples.
+On the other hand, you can also handle the response with operations like onSuccess, compose, bodyHandler, etc.
+The following examples demonstrate handling responses with the operation onSuccess :
 
 The following example shows an example using HTTP client in {VertX} {v3x} releases:
 


### PR DESCRIPTION
Motivation:

Context
Now in vertx 4.0.0 when you do some HttpClientRequest and get the result if you want to do after some operation (compose, succeed,etc) with the result before sending it, you have to add the response method that returns the Future

This change is shown in vertx examples in the core/http/proxy/client.java :
request.response().compose

vert-x3/vertx-examples@1ddfd8c#diff-330da0139766c23d1b970aa604bae5ed935b15ce6800348c696b0a5f6744f74b