### PR TITLE
Fix secret options v4 example (it's `setBuffer` not `setSecret`)

### DIFF
--- a/asciidoc/modules/con_mg_changes-in-key-management.adoc
+++ b/asciidoc/modules/con_mg_changes-in-key-management.adoc
@@ -32,7 +32,7 @@ The following example shows how methods of `PubSecKeyOptions` class should be us
 ----
 new PubSecKeyOptions()
     .setAlgorithm("HS256")
-    .setSecretKey("password")
+    .setBuffer("password")
 ----
 
 == Updates in public secret keys management


### PR DESCRIPTION
In v4 it's [PubSecKeyOptions::setBuffer](https://github.com/eclipse-vertx/vertx-auth/blob/b9bfc619a320bfeb3053ac0513ffbf68f97a3fb1/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java#L80) not `PubSecKeyOptions::setSecretKey` (probably a copy-paste typo?)
